### PR TITLE
Configure GitHub action to start server on PRs

### DIFF
--- a/.github/workflows/start_pull_request.yaml
+++ b/.github/workflows/start_pull_request.yaml
@@ -1,0 +1,23 @@
+name: Start Server on Pull Request
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build project
+        run: npm run build
+
+      - name: Start server for CI/CD
+        run: npm run start-ci

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "start-ci": "npm run build && npx http-server ./build -p 3001"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
This pull request (PR) is to set up a GitHub action whenever a pull request is made to `main`. The GitHub action will start up a server on `localhost:3001` to avoid any conflicts with other ports. The purpose of this action is so that we can see what the project looks like before merging it into main.

